### PR TITLE
Catch errors on send

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,16 @@ RtcDataStream.prototype.write = function(data) {
 }
 
 RtcDataStream.prototype._write = function(data) {
-  this.rtc.send(data)
+  try {
+    this.rtc.send(data);
+  } catch(e) {
+    if (e.name == 'NetworkError') {
+      // the stream closed but didn't tell us
+      this.onClose(e);
+    } else {
+      this.onError(e);
+    }
+  }
 }
 
 RtcDataStream.prototype.end = function(data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtc-data-stream",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "convert a webRtc connection into a stream",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was getting NetworkErrors when trying to send data to a stream when the underlying data channel had its remote closed. This patch will detect a network error on send and close the connection, and in case another type of error occurs, simply emit an error on the stream without closing.
